### PR TITLE
Add a benchmark between CPU and GPU models

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,11 +1,21 @@
 # Benchmarks
-The naming for the benchmarks is a little confusing. Right now, they are marked with the benchmarks_ tag in their filename. The first one written, "benchmarks.jl" is an exception.
 
-## Benchmarks.jl
+The naming for the benchmarks is a little confusing.
+Right now, they are marked with the prefix `benchmarks_` in their filename.
+The first one written, `benchmarks.jl` is an exception.
+
+## benchmarks.jl
+
 This was written to query some timings specific to the optimization problem, i.e., Linear Algebra solve time, VecchiaCache creation time, and solving model time. 
 
-## Benchmarks_pprof.jl
+## benchmarks_pprof.jl
+
 This was written to generate the flame graph for VecchiaMLE using PProf, hence the name. 
 
-## Benchmarks_data.jl
+## benchmarks_data.jl
+
 This was written to see how big of a problem we could solve. It reports the time and memory use for VecchiaMLE for increasing dimensions, stopping when we hit a large time (25s). 
+
+## benchmarks_models.jl
+
+The file `benchmarks_models.jl` compares the evaluation time of the functions of the same `VecchiaModel` on the `CPU` and the `GPU`.

--- a/benchmarks/benchmarks_models.jl
+++ b/benchmarks/benchmarks_models.jl
@@ -1,0 +1,163 @@
+using VecchiaMLE
+using VecchiaMLE: CPU, GPU
+using NLPModels
+using CUDA
+
+function benchmarks_models(; n::Int=10, k::Int=10, Number_of_Samples::Int=100, verbose::Bool=true)
+  params = [5.0, 0.2, 2.25, 0.25] 
+  xyGrid = VecchiaMLE.generate_xyGrid(n)
+  MatCov = VecchiaMLE.generate_MatCov(n, params, xyGrid)
+
+  samples_cpu = VecchiaMLE.generate_Samples(MatCov, n, Number_of_Samples; mode=CPU)
+  samples_gpu = VecchiaMLE.generate_Samples(MatCov, n, Number_of_Samples; mode=GPU)
+  model_cpu = VecchiaMLE.VecchiaModelCPU(samples_cpu, k, xyGrid)  # warm up
+  model_gpu = VecchiaMLE.VecchiaModelGPU(samples_gpu, k, xyGrid)  # warm up
+  timer_model_cpu = @elapsed VecchiaMLE.VecchiaModelCPU(samples_cpu, k, xyGrid)
+  timer_model_gpu = CUDA.@elapsed VecchiaMLE.VecchiaModelGPU(samples_gpu, k, xyGrid)
+  ratio_timer_model = timer_model_cpu / timer_model_gpu
+  verbose && println("-- Time to create the VecchiaModel --")
+  verbose && println("CPU: $timer_model_cpu")
+  verbose && println("GPU: $timer_model_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_model")
+  verbose && println()
+
+  x_cpu = get_x0(model_cpu)
+  x_gpu = get_x0(model_gpu)
+  obj(model_cpu, x_cpu)  # warm up
+  obj(model_gpu, x_gpu)  # warm up 
+  timer_obj_cpu = @elapsed obj(model_cpu, x_cpu)
+  timer_obj_gpu = CUDA.@elapsed obj(model_gpu, x_gpu)
+  ratio_timer_obj = timer_obj_cpu / timer_obj_gpu
+  verbose && println("-- Time to evaluate the objective --")
+  verbose && println("CPU: $timer_obj_cpu")
+  verbose && println("GPU: $timer_obj_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_obj")
+  verbose && println()
+
+  g_cpu = similar(x_cpu)
+  g_gpu = similar(x_gpu)
+  grad!(model_cpu, x_cpu, g_cpu)  # warm up
+  grad!(model_gpu, x_gpu, g_gpu)  # warm up
+  timer_grad_cpu = @elapsed grad!(model_cpu, x_cpu, g_cpu)
+  timer_grad_gpu = CUDA.@elapsed grad!(model_gpu, x_gpu, g_gpu)
+  ratio_timer_grad = timer_grad_cpu / timer_grad_gpu
+  verbose && println("-- Time to evaluate the gradient --")
+  verbose && println("CPU: $timer_grad_cpu")
+  verbose && println("GPU: $timer_grad_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_grad")
+  verbose && println()
+
+  c_cpu = Vector{eltype(x_cpu)}(undef, get_ncon(model_cpu))
+  c_gpu = CuVector{eltype(x_gpu)}(undef, get_ncon(model_gpu))
+  cons!(model_cpu, x_cpu, c_cpu)  # warm up
+  cons!(model_gpu, x_gpu, c_gpu)  # warm up
+  timer_cons_cpu = @elapsed cons!(model_cpu, x_cpu, c_cpu)
+  timer_cons_gpu = CUDA.@elapsed cons!(model_gpu, x_gpu, c_gpu)
+  ratio_timer_cons = timer_cons_cpu / timer_cons_gpu
+  verbose && println("-- Time to evaluate the constraints --")
+  verbose && println("CPU: $timer_cons_cpu")
+  verbose && println("GPU: $timer_cons_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_cons")
+  verbose && println()
+
+  hrows_cpu = Vector{Int}(undef, model_cpu.meta.nnzh)
+  hcols_cpu = Vector{Int}(undef, model_cpu.meta.nnzh)
+  hrows_gpu = CuVector{Int}(undef, model_gpu.meta.nnzh)
+  hcols_gpu = CuVector{Int}(undef, model_gpu.meta.nnzh)
+  hess_structure!(model_cpu, hrows_cpu, hcols_cpu)  # warm up
+  hess_structure!(model_gpu, hrows_gpu, hcols_gpu)  # warm up
+  timer_hess_structure_cpu = @elapsed hess_structure!(model_cpu, hrows_cpu, hcols_cpu)
+  timer_hess_structure_gpu = CUDA.@elapsed hess_structure!(model_gpu, hrows_gpu, hcols_gpu)
+  ratio_timer_hess_structure = timer_hess_structure_cpu / timer_hess_structure_gpu
+  verbose && println("-- Time to evaluate the structure of the Hessian --")
+  verbose && println("CPU: $timer_hess_structure_cpu")
+  verbose && println("GPU: $timer_hess_structure_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_hess_structure")
+  verbose && println()
+
+  hvals_cpu = Vector{eltype(x_cpu)}(undef, model_cpu.meta.nnzh)
+  hvals_gpu = CuVector{eltype(x_gpu)}(undef, model_gpu.meta.nnzh)
+  hess_coord!(model_cpu, x_cpu, hvals_cpu)  # warm up
+  hess_coord!(model_gpu, x_gpu, hvals_gpu)  # warm up
+  timer_hess_obj_cpu = @elapsed hess_coord!(model_cpu, x_cpu, hvals_cpu)
+  timer_hess_obj_gpu = CUDA.@elapsed hess_coord!(model_gpu, x_gpu, hvals_gpu)
+  ratio_timer_hess_obj = timer_hess_obj_cpu / timer_hess_obj_gpu
+  verbose && println("-- Time to evaluate the Hessian of the objective --")
+  verbose && println("CPU: $timer_hess_obj_cpu")
+  verbose && println("GPU: $timer_hess_obj_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_hess_obj")
+  verbose && println()
+
+  y_cpu = get_y0(model_cpu)
+  y_gpu = get_y0(model_gpu)
+  hess_coord!(model_cpu, x_cpu, y_cpu, hvals_cpu)  # warm up
+  hess_coord!(model_gpu, x_gpu, y_gpu, hvals_gpu)  # warm up
+  timer_hess_lag_cpu = @elapsed hess_coord!(model_cpu, x_cpu, y_cpu, hvals_cpu)
+  timer_hess_lag_gpu = CUDA.@elapsed hess_coord!(model_gpu, x_gpu, y_gpu, hvals_gpu)
+  ratio_timer_hess_lag = timer_hess_lag_cpu / timer_hess_lag_gpu
+  verbose && println("-- Time to evaluate the Hessian of the Lagrangian --")
+  verbose && println("CPU: $timer_hess_lag_cpu")
+  verbose && println("GPU: $timer_hess_lag_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_hess_lag")
+  verbose && println()
+
+  jrows_cpu = Vector{Int}(undef, model_cpu.meta.nnzj)
+  jcols_cpu = Vector{Int}(undef, model_cpu.meta.nnzj)
+  jrows_gpu = CuVector{Int}(undef, model_gpu.meta.nnzj)
+  jcols_gpu = CuVector{Int}(undef, model_gpu.meta.nnzj)
+  jac_structure!(model_cpu, jrows_cpu, jcols_cpu)  # warm up
+  jac_structure!(model_gpu, jrows_gpu, jcols_gpu)  # warm up
+  timer_jac_structure_cpu = @elapsed jac_structure!(model_cpu, jrows_cpu, jcols_cpu)
+  timer_jac_structure_gpu = CUDA.@elapsed jac_structure!(model_gpu, jrows_gpu, jcols_gpu)
+  ratio_timer_jac_structure = timer_jac_structure_cpu / timer_jac_structure_gpu
+  verbose && println("-- Time to evaluate the structure of the Jacobian --")
+  verbose && println("CPU: $timer_jac_structure_cpu")
+  verbose && println("GPU: $timer_jac_structure_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_jac_structure")
+  verbose && println()
+
+  jvals_cpu = Vector{eltype(x_cpu)}(undef, model_cpu.meta.nnzj)
+  jvals_gpu = CuVector{eltype(x_gpu)}(undef, model_gpu.meta.nnzj)
+  jac_coord!(model_cpu, x_cpu, jvals_cpu)  # warm up
+  jac_coord!(model_gpu, x_gpu, jvals_gpu)  # warm up
+  timer_jac_cpu = @elapsed jac_coord!(model_cpu, x_cpu, jvals_cpu)
+  timer_jac_gpu = CUDA.@elapsed jac_coord!(model_gpu, x_gpu, jvals_gpu)
+  ratio_timer_jac = timer_jac_cpu / timer_jac_gpu
+  verbose && println("-- Time to evaluate the Jacobian --")
+  verbose && println("CPU: $timer_jac_cpu")
+  verbose && println("GPU: $timer_jac_gpu")
+  verbose && println("Ratio CPU / GPU: $ratio_timer_jac")
+  verbose && println()
+
+  timer_cpu = Dict(:model => timer_model_cpu,
+                   :obj => timer_obj_cpu,
+                   :grad! => timer_grad_cpu,
+                   :cons! => timer_cons_cpu,
+                   :jac_structure! => timer_jac_structure_cpu,
+                   :hess_structure! => timer_hess_structure_cpu,
+                   :jac_coord! => timer_jac_cpu,
+                   :hess_coord! => timer_hess_obj_cpu,
+                   :hess_lag_coord! => timer_hess_lag_cpu)
+
+  timer_gpu = Dict(:model => timer_model_gpu,
+                   :obj => timer_obj_gpu,
+                   :grad! => timer_grad_gpu,
+                   :cons! => timer_cons_gpu,
+                   :jac_structure! => timer_jac_structure_gpu,
+                   :hess_structure! => timer_hess_structure_gpu,
+                   :jac_coord! => timer_jac_gpu,
+                   :hess_coord! => timer_hess_obj_gpu,
+                   :hess_lag_coord! => timer_hess_lag_gpu)
+
+  timer_ratio = Dict(:model => ratio_timer_model,
+                     :obj => ratio_timer_obj,
+                     :grad! => ratio_timer_grad,
+                     :cons! => ratio_timer_cons,
+                     :jac_structure! => ratio_timer_jac_structure,
+                     :hess_structure! => ratio_timer_hess_structure,
+                     :jac_coord! => ratio_timer_jac,
+                     :hess_coord! => ratio_timer_hess_obj,
+                     :hess_lag_coord! => ratio_timer_hess_lag)
+
+  return timer_cpu, timer_gpu, timer_ratio
+end


### PR DESCRIPTION
@CalebDerrickson 
We will be able to determine for which size of problems the GPU outperforms CPU.
Ratio >1 means that the GPU is faster than the CPU.

```julia
julia> benchmarks_models(n=10, k=10)
-- Time to create the VecchiaModel --
CPU: 0.005642553
GPU: 0.019428287
Ratio CPU / GPU: 0.29042977832839706

-- Time to evaluate the objective --
CPU: 1.2949e-5
GPU: 0.000154944
Ratio CPU / GPU: 0.08357212617242436

-- Time to evaluate the gradient --
CPU: 1.2499e-5
GPU: 0.000102399994
Ratio CPU / GPU: 0.12206055412151248

-- Time to evaluate the constraints --
CPU: 1.37e-6
GPU: 7.0656e-5
Ratio CPU / GPU: 0.019389718596935585

-- Time to evaluate the structure of the Hessian --
CPU: 1.347e-5
GPU: 0.000145408
Ratio CPU / GPU: 0.0926358904565227

-- Time to evaluate the Hessian of the objective --
CPU: 3.86e-6
GPU: 2.8672e-5
Ratio CPU / GPU: 0.13462611347327177

-- Time to evaluate the Hessian of the Lagrangian --
CPU: 2.6e-6
GPU: 3.584e-5
Ratio CPU / GPU: 0.07254464421849637

-- Time to evaluate the structure of the Jacobian --
CPU: 6.3e-7
GPU: 4.608e-5
Ratio CPU / GPU: 0.013671874948167486

-- Time to evaluate the Jacobian --
CPU: 1.14e-6
GPU: 2.9696e-5
Ratio CPU / GPU: 0.038389007795837066
```
```julia
julia> benchmarks_models(n=50, k=50)
-- Time to create the VecchiaModel --
CPU: 3.312971432
GPU: 3.58476
Ratio CPU / GPU: 0.9241822263190985

-- Time to evaluate the objective --
CPU: 0.004967496
GPU: 0.013027936
Ratio CPU / GPU: 0.38129569534656005

-- Time to evaluate the gradient --
CPU: 0.004963567
GPU: 0.013005824
Ratio CPU / GPU: 0.3816418756347582

-- Time to evaluate the constraints --
CPU: 2.003e-5
GPU: 9.1136004e-5
Ratio CPU / GPU: 0.21978141615026525

-- Time to evaluate the structure of the Hessian --
CPU: 0.003294318
GPU: 0.0136704
Ratio CPU / GPU: 0.24098183314321592

-- Time to evaluate the Hessian of the objective --
CPU: 0.002731752
GPU: 0.000118784
Ratio CPU / GPU: 22.997642286029276

-- Time to evaluate the Hessian of the Lagrangian --
CPU: 0.002773031
GPU: 0.000117760006
Ratio CPU / GPU: 23.54815604811558

-- Time to evaluate the structure of the Jacobian --
CPU: 2.21e-6
GPU: 3.8912e-5
Ratio CPU / GPU: 0.05679481968961062

-- Time to evaluate the Jacobian --
CPU: 1.475e-5
GPU: 2.7648e-5
Ratio CPU / GPU: 0.5334924678094869
```