### PR TITLE
Add a default lvar in VecchiaModel

### DIFF
--- a/src/models/VecchiaModel.jl
+++ b/src/models/VecchiaModel.jl
@@ -31,7 +31,7 @@ function VecchiaModel(::Type{S}, iVecchiaMLE::VecchiaMLEInput) where {S<:Abstrac
     else
         # Always ensure that the diagonal coefficient Lᵢᵢ of the Vecchia approximation are strictly positive
         view(lvar, cache.diagL) .= 1e-16
-        view(uvar, cache.nnzL+1:nvar) .= log(1e-16)
+        view(lvar, cache.nnzL+1:nvar) .= log(1e-16)
     end
 
     if !isnothing(iVecchiaMLE.uvar_diag)

--- a/src/models/VecchiaModel.jl
+++ b/src/models/VecchiaModel.jl
@@ -31,7 +31,7 @@ function VecchiaModel(::Type{S}, iVecchiaMLE::VecchiaMLEInput) where {S<:Abstrac
     else
         # Always ensure that the diagonal coefficient Lᵢᵢ of the Vecchia approximation are strictly positive
         view(lvar, cache.diagL) .= 1e-16
-        view(uvar, cache.nnzL+1:nvar) .= -log(1e-16)
+        view(uvar, cache.nnzL+1:nvar) .= log(1e-16)
     end
 
     if !isnothing(iVecchiaMLE.uvar_diag)

--- a/src/models/VecchiaModel.jl
+++ b/src/models/VecchiaModel.jl
@@ -27,7 +27,7 @@ function VecchiaModel(::Type{S}, iVecchiaMLE::VecchiaMLEInput) where {S<:Abstrac
     #TODO: Add checks to sanitize_input, also provide bounds if none were given in VecchiaMLEInput constructor
     if !isnothing(iVecchiaMLE.lvar_diag)
         view(lvar, cache.diagL) .= iVecchiaMLE.lvar_diag
-        view(uvar, cache.nnzL+1:nvar) .= log.(iVecchiaMLE.lvar_diag)
+        view(lvar, cache.nnzL+1:nvar) .= log.(iVecchiaMLE.lvar_diag)
     else
         # Always ensure that the diagonal coefficient Lᵢᵢ of the Vecchia approximation are strictly positive
         view(lvar, cache.diagL) .= 1e-16

--- a/src/models/VecchiaModel.jl
+++ b/src/models/VecchiaModel.jl
@@ -28,6 +28,10 @@ function VecchiaModel(::Type{S}, iVecchiaMLE::VecchiaMLEInput) where {S<:Abstrac
     if !isnothing(iVecchiaMLE.lvar_diag)
         view(lvar, cache.diagL) .= iVecchiaMLE.lvar_diag
         view(uvar, cache.nnzL+1:nvar) .= log.(iVecchiaMLE.lvar_diag)
+    else
+        # Always ensure that the diagonal coefficient Lᵢᵢ of the Vecchia approximation are strictly positive
+        view(lvar, cache.diagL) .= 1e-16
+        view(uvar, cache.nnzL+1:nvar) .= -16
     end
 
     if !isnothing(iVecchiaMLE.uvar_diag)

--- a/src/models/VecchiaModel.jl
+++ b/src/models/VecchiaModel.jl
@@ -31,7 +31,7 @@ function VecchiaModel(::Type{S}, iVecchiaMLE::VecchiaMLEInput) where {S<:Abstrac
     else
         # Always ensure that the diagonal coefficient Lᵢᵢ of the Vecchia approximation are strictly positive
         view(lvar, cache.diagL) .= 1e-16
-        view(uvar, cache.nnzL+1:nvar) .= -16
+        view(uvar, cache.nnzL+1:nvar) .= -log(1e-16)
     end
 
     if !isnothing(iVecchiaMLE.uvar_diag)


### PR DESCRIPTION
@CalebDerrickson We know that L_{i,i} > 0 whatever the solution we obtain, I propose to add a lower bound on the relevant variables by default in the `VecchiaModel` to ensure that.

I also found a typo, `uvar` was used instead of `lvar`.

Comment: please squash + merge