### PR TITLE
Support lower or upper triangular matrices for the sparsity pattern

### DIFF
--- a/src/models/VecchiaModel.jl
+++ b/src/models/VecchiaModel.jl
@@ -112,15 +112,11 @@ function create_vecchia_cache(::Type{S}, iVecchiaMLE::VecchiaMLEInput, uplo::Sym
 
     vecchia_build_B!(B, iVecchiaMLE.samples, iVecchiaMLE.lambda, rowsL, colptrL, hess_obj_vals, n, m)
 
-    diagL = Vector{Int}(undef, n)
     if uplo == :L
-        for i = 1:n
-            diagL[i] = colptrL[i]
-        end
+        diagL = colptrL[1:n]
     elseif uplo == :U
-        for i = 1:n
-            diagL[i] = colptrL[i+1] - 1
-        end
+        diagL = colptrL[2:n+1]
+        diagL .-= 1
     else
         error("Unsupported uplo = $uplo")
     end
@@ -141,7 +137,6 @@ function create_vecchia_cache(I::Vector{Int}, J::Vector{Int}, samples::Matrix{T}
     nnz_coo = length(I)
     V = ones(Int, nnz_coo)
     P = sparse(I, J, V, n, n)
-    n = size(P, 1)
 
     # SPARSITY PATTERN OF L IN CSC FORMAT.
     rowsL = P.rowval
@@ -172,15 +167,11 @@ function create_vecchia_cache(I::Vector{Int}, J::Vector{Int}, samples::Matrix{T}
 
     vecchia_build_B!(B, samples, 0.0, rowsL, colptrL, hess_obj_vals, n, m)
 
-    diagL = Vector{Int}(undef, n)
     if uplo == :L
-        for i = 1:n
-            diagL[i] = colptrL[i]
-        end
+        diagL = colptrL[1:n]
     elseif uplo == :U
-        for i = 1:n
-            diagL[i] = colptrL[i+1] - 1
-        end
+        diagL = colptrL[2:n+1]
+        diagL .-= 1
     else
         error("Unsupported uplo = $uplo")
     end


### PR DESCRIPTION
On top of #124 
@cgeoga 
```julia
using VecchiaMLE
using LinearAlgebra
using SparseArrays

n = 400                                   # Dimension
number_of_samples = 100 # Number of Samples to generate

params = [5.0, 0.2, 2.25, 0.25]
# This analysis will be done in 2D.
ptset = VecchiaMLE.generate_safe_xyGrid(n)
MatCov = VecchiaMLE.generate_MatCov(params, ptset)
samples = VecchiaMLE.generate_samples(MatCov, number_of_samples)

P = ones(n, n)
P = tril(P)
P = sparse(P)
I, J, V = findnz(P)

nlp1 = VecchiaModel(I, J, samples; uplo=:L)

P = ones(n, n)
P = triu(P)
P = sparse(P)
I, J, V = findnz(P)

nlp2 = VecchiaModel(I, J, samples; uplo=:U)
```